### PR TITLE
Support Windows new lines.

### DIFF
--- a/stayopen.go
+++ b/stayopen.go
@@ -113,11 +113,13 @@ func NewStayOpen(exiftool string, flags ...string) (*Stayopen, error) {
 }
 
 func splitReadyToken(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	if i := bytes.Index(data, []byte("\n{ready}\n")); i >= 0 {
-		if atEOF && len(data) == (i+9) { // nothing left to scan
-			return i + 9, data[:i], bufio.ErrFinalToken
-		} else {
-			return i + 9, data[:i], nil
+	if i := bytes.Index(data, []byte("\n{ready")); i >= 0 {
+		if n := bytes.IndexByte(data[i+1:], '\n'); n >= 0 {
+			if atEOF && len(data) == (n+i+2) { // nothing left to scan
+				return n + i + 2, data[:i+1], bufio.ErrFinalToken
+			} else {
+				return n + i + 2, data[:i+1], nil
+			}
 		}
 	}
 

--- a/stayopen.go
+++ b/stayopen.go
@@ -113,12 +113,12 @@ func NewStayOpen(exiftool string, flags ...string) (*Stayopen, error) {
 }
 
 func splitReadyToken(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	if i := bytes.Index(data, []byte("\n{ready")); i >= 0 {
-		if n := bytes.IndexByte(data[i+1:], '\n'); n >= 0 {
-			if atEOF && len(data) == (n+i+2) { // nothing left to scan
-				return n + i + 2, data[:i+1], bufio.ErrFinalToken
+	if i := bytes.Index(data, []byte("{ready")); i >= 0 {
+		if n := bytes.IndexByte(data[i:], '\n'); n >= 0 {
+			if atEOF && len(data) == (n+i+1) { // nothing left to scan
+				return n + i + 1, data[:i], bufio.ErrFinalToken
 			} else {
-				return n + i + 2, data[:i+1], nil
+				return n + i + 1, data[:i], nil
 			}
 		}
 	}

--- a/stayopen_test.go
+++ b/stayopen_test.go
@@ -59,19 +59,19 @@ func TestSplitReadyToken(t *testing.T) {
 	advance, token, err := splitReadyToken(data, false)
 	assert.NoError(err)
 	assert.Equal(12, advance)
-	assert.Equal([]byte("xxx"), token)
+	assert.Equal([]byte("xxx\n"), token)
 
 	data = data[advance:]
 	advance, token, err = splitReadyToken(data, false)
 	assert.NoError(err)
 	assert.Equal(12, advance)
-	assert.Equal([]byte("yyy"), token)
+	assert.Equal([]byte("yyy\n"), token)
 
 	data = data[advance:]
 	advance, token, err = splitReadyToken(data, true)
 	assert.Equal(bufio.ErrFinalToken, err)
 	assert.Equal(12, advance)
-	assert.Equal([]byte("zzz"), token)
+	assert.Equal([]byte("zzz\n"), token)
 }
 
 // TestSplitReadyTokenPartial tests that more data is requested
@@ -104,6 +104,6 @@ func TestSplitReadyTokenFinalToken(t *testing.T) {
 	data := []byte("--\n{ready}\n") // just a ready token
 	advance, token, err := splitReadyToken(data, true)
 	assert.Equal(11, advance)
-	assert.Equal([]byte("--"), token)
+	assert.Equal([]byte("--\n"), token)
 	assert.Equal(bufio.ErrFinalToken, err)
 }


### PR DESCRIPTION
This adds support for Windows new line (`\r\n` sequences).

It changes behavior (and tests) to make it so that the final new line output for each command is passed to the caller (which I personally think makes sense, and makes for easier code).

If this is an impediment to getting the PR accepted, please say so, and I'll try to come up with something that respects current behavior.