### PR TITLE
Add detection for Windows line termination \r\n in stay_open mode

### DIFF
--- a/stayopen_test.go
+++ b/stayopen_test.go
@@ -74,6 +74,28 @@ func TestSplitReadyToken(t *testing.T) {
 	assert.Equal([]byte("zzz"), token)
 }
 
+func TestSplitReadyTokenWindows(t *testing.T) {
+	assert := assert.New(t)
+	data := []byte("xxx\r\n{ready}\r\nyyy\r\n{ready}\r\nzzz\r\n{ready}\r\n")
+
+	advance, token, err := splitReadyToken(data, false)
+	assert.NoError(err)
+	assert.Equal(14, advance)
+	assert.Equal([]byte("xxx"), token)
+
+	data = data[advance:]
+	advance, token, err = splitReadyToken(data, false)
+	assert.NoError(err)
+	assert.Equal(14, advance)
+	assert.Equal([]byte("yyy"), token)
+
+	data = data[advance:]
+	advance, token, err = splitReadyToken(data, true)
+	assert.Equal(bufio.ErrFinalToken, err)
+	assert.Equal(14, advance)
+	assert.Equal([]byte("zzz"), token)
+}
+
 // TestSplitReadyTokenPartial tests that more data is requested
 // when we don't have a full delimter yet
 func TestSplitReadyTokenPartial(t *testing.T) {


### PR DESCRIPTION
Perl on Windows [0] outputs \r\n for line terminations.  This causes
exiftool's stayopen mode to behave different on Windows vs POSIX
systems, which uses \n.

This change detects if there is a \r in the line terminations and splits
the output accordingly.

See other PR #11 for some context. 